### PR TITLE
refactor: switch to flake-parts

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,34 +1,51 @@
 {
   "nodes": {
-    "flake-utils": {
+    "flake-parts": {
       "inputs": {
-        "systems": "systems"
+        "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1685518550,
-        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
+        "lastModified": 1685662779,
+        "narHash": "sha256-cKDDciXGpMEjP1n6HlzKinN0H+oLmNpgeCTzYnsA2po=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "71fb97f0d875fd4de4994dfb849f2c75e17eb6c3",
         "type": "github"
       },
       "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
+        "id": "flake-parts",
+        "type": "indirect"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1685655444,
-        "narHash": "sha256-6EujQNAeaUkWvpEZZcVF8qSfQrNVWFNNGbUJxv/A5a8=",
+        "lastModified": 1685714850,
+        "narHash": "sha256-OcvbIJq4CGwwFr9m7M/SQcDPZ64hhR4t77oZgEeh7ZY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e635192892f5abbc2289eaac3a73cdb249abaefd",
+        "rev": "c6ffce3d5df7b4c588ce80a0c6e2d2348a611707",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1685564631,
+        "narHash": "sha256-8ywr3AkblY4++3lIVxmrWZFzac7+f32ZEhH/A8pNscI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4f53efe34b3a8877ac923b9350c874e3dcd5dc0a",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
         "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
@@ -36,23 +53,8 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
+        "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -2,267 +2,36 @@
   description = "guacamole-server";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-
-    flake-utils.url = "github:numtide/flake-utils";
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
   };
 
-  outputs = { self, flake-utils, nixpkgs }:
-    {
-      nixosModules = {
-        guacamole = { config, lib, pkgs, ... }:
-          with lib;
-          let
-            cfg = config.services.guacamole;
-          in
-          {
-            meta = {
-              maintainers = [ ];
-            };
+  outputs = inputs@{ flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [
+        "x86_64-linux"
+        "x86_64-darwin"
+        "aarch64-linux"
+        "aarch64-darwin"
+      ];
 
-            options = {
-              services.guacamole = {
-                enable = mkEnableOption (lib.mdDoc "Apache Guacamole");
+      imports = [
+        ./overlay.nix
+      ];
 
-                extraEnvironment = mkOption {
-                  type = types.listOf types.str;
-                  default = [ ];
-                  example = [ "ENVIRONMENT=production" ];
-                  description = lib.mdDoc "Environment Variables to pass to guacd";
-                };
+      perSystem = { config, self', inputs', pkgs, system, ... }: {
+        # TODO: Find a better way to do this.
+        _module.args.pkgs = import inputs.nixpkgs {
+          inherit system;
+          overlays = [ inputs.self.overlays.default ];
+        };
 
-                baseDir = mkOption {
-                  type = lib.types.path;
-                  default = "/etc/guacamole";
-                  description = lib.mdDoc ''
-                    Location of $GUACAMOLE_HOME
-                  '';
-                };
-
-                guacdBindHost = mkOption {
-                  type = types.str;
-                  default = "127.0.0.1";
-                  description = lib.mdDoc ''
-                    bind_host parameter
-                  '';
-                };
-
-                purifyOnStart = mkOption {
-                  type = types.bool;
-                  default = true;
-                  description = lib.mdDoc ''
-                    On startup, the `baseDir` directory is populated with various files,
-                    subdirectories and symlinks. If this option is enabled, these items
-                    are first removed. This prevents interference from remainders of an
-                    old configuration, so it's recommended to enable this option.
-                  '';
-                };
-
-                guacamoleProperties = mkOption {
-                  type = types.lines;
-                  default = "";
-                  description = lib.mdDoc ''
-                    Configuration written to $GUACAMOLE_HOME/guacamole.properties
-                  '';
-                };
-
-                logbackXml = mkOption {
-                  type = types.lines;
-                  default = "";
-                  description = lib.mdDoc ''
-                    Configuration written to $GUACAMOLE_HOME/logback.xml
-                  '';
-                };
-
-                userMapping = mkOption {
-                  type = types.lines;
-                  default = "";
-                  description = lib.mdDoc ''
-                    Configuration written to $GUACAMOLE_HOME/user-mapping.xml
-                  '';
-                };
-              };
-
-            };
-
-            config = mkIf cfg.enable {
-              systemd.services.guacd = {
-                description = "Apache Guacamole server";
-                wantedBy = [ "multi-user.target" ];
-                after = [ "network.target" ];
-
-                serviceConfig = {
-                  Environment = [
-                    "GUACAMOLE_HOME=${cfg.baseDir}"
-                  ] ++ cfg.extraEnvironment;
-                  ExecStart = "${pkgs.guacamole-server}/bin/guacd -f -b ${cfg.guacdBindHost}";
-                };
-
-                preStart = ''
-                  # Create and clean the base directory
-                  ${lib.optionalString cfg.purifyOnStart ''
-                  rm -rf ${cfg.baseDir}/{guacamole.properties,logback.xml,extensions,lib,user-mapping.xml}
-                  ''}
-                  mkdir -p ${cfg.baseDir}
-
-                  # Setup guacamole.properties
-                  ${lib.optionalString (cfg.guacamoleProperties != "") ''
-                    cat << EOF > ${cfg.baseDir}/guacamole.properties
-                    ${cfg.guacamoleProperties}
-                    EOF
-                  ''}
-
-                  # Setup logback.xml
-                  ${lib.optionalString (cfg.logbackXml != "") ''
-                    cat << EOF > ${cfg.baseDir}/logback.xml
-                    ${cfg.logbackXml}
-                    EOF
-                  ''}
-
-                  # Setup user-mapping.xml
-                  ${lib.optionalString (cfg.userMapping != "") ''
-                    cat << EOF > ${cfg.baseDir}/user-mapping.xml
-                    ${cfg.userMapping}
-                    EOF
-                  ''}
-                '';
-              };
-
-
-              services.tomcat = {
-                enable = true;
-
-                webapps = [ (pkgs.guacamole-client + "/guacamole-client-1.5.0.war") ];
-                extraEnvironment = [ "GUACAMOLE_HOME=${cfg.baseDir}" ];
-              };
-            };
-          };
+        packages = {
+          inherit (pkgs) guacamole-server guacamole-client;
+        };
       };
-    } // flake-utils.lib.eachDefaultSystem
-      (
-        system:
-        let
-          pkgs = import nixpkgs {
-            inherit system;
-            overlays = [
-              (self: super: rec { })
-            ];
-          };
-        in
-        {
-          packages.guacamole-server = with pkgs;
-            stdenv.mkDerivation
-              rec {
-                pname = "guacamole";
-                version = "1.5.0";
 
-                src = fetchFromGitHub {
-                  owner = "apache";
-                  repo = "guacamole-server";
-                  rev = version;
-                  sha256 = "sha256-aG2Fcll0TgLokI2iAu5Gy7LKGr3FSX2tEFAEFiJCVkw=";
-                };
-
-                NIX_CFLAGS_COMPILE = [
-                  "-Wno-error=format-truncation"
-                  "-Wno-error=format-overflow"
-                ];
-
-                buildInputs = [
-                  freerdp
-                  autoreconfHook
-                  pkg-config
-                  cairo
-                  libpng
-                  libjpeg_turbo
-                  libossp_uuid
-                  pango
-                  libssh2
-                  libvncserver
-                  libpulseaudio
-                  openssl
-                  libvorbis
-                  libwebp
-                  libtelnet
-                  perl
-                  makeWrapper
-                ];
-
-                propogatedBuildInputs = [
-                  freerdp
-                  autoreconfHook
-                  pkg-config
-                  cairo
-                  libpng
-                  libjpeg_turbo
-                  libossp_uuid
-                  freerdp
-                  pango
-                  libssh2
-                  libvncserver
-                  libpulseaudio
-                  openssl
-                  libvorbis
-                  libwebp
-                  inetutils
-                ];
-
-                patchPhase = ''
-                  patchShebangs ./src/protocols/rdp/**/*.pl
-                  substituteInPlace ./configure.ac --replace "FREERDP2_PLUGIN_DIR=" "FREERDP2_PLUGIN_DIR=${placeholder "out"}/lib"
-
-                '';
-
-                postInstall = ''
-                  wrapProgram $out/sbin/guacd --prefix LD_LIBRARY_PATH ":" $out/lib
-                '';
-
-                meta = with lib; {
-                  description = "Clientless remote desktop gateway";
-                  homepage = "https://guacamole.incubator.apache.org/";
-                  license = licenses.asl20;
-                  maintainers = with maintainers; [ ];
-                  platforms = [ "x86_64-linux" "i686-linux" ];
-                };
-              };
-
-          packages.guacamole-client = with pkgs;
-            stdenv.mkDerivation
-              rec {
-                pname = "guacamole-client";
-                version = "1.5.0";
-
-                src = fetchurl {
-                  url = "https://archive.apache.org/dist/guacamole/1.5.0/binary/guacamole-1.5.0.war";
-                  sha256 = "sha256-nE6AeqcLwTjztsxmzES3XaqUSgFZRLmrb3gNeGhJhiA=";
-                };
-
-                dontUnpack = true;
-
-                buildInputs = [
-                ];
-
-                propogatedBuildInputs = [
-                ];
-
-                buildPhase = ''
-                '';
-
-                installPhase = ''
-                  mkdir $out
-                  cp $src $out/${pname}-${version}.war
-                '';
-
-                meta = with lib;
-                  {
-                    description = "Clientless remote desktop gateway";
-                    homepage = "https://guacamole.incubator.apache.org/";
-                    license = licenses.asl20;
-                    maintainers = with maintainers; [ ];
-                    platforms = [ "x86_64-linux" "i686-linux" ];
-                  };
-              };
-        }
-      );
-
+      flake.nixosModules = {
+        guacamole = import ./modules/guacamole.nix;
+      };
+    };
 }

--- a/modules/guacamole.nix
+++ b/modules/guacamole.nix
@@ -1,0 +1,135 @@
+{ config
+, lib
+, pkgs
+, ...
+}:
+let
+  cfg = config.services.guacamole;
+in
+{
+  options = {
+    services.guacamole = {
+      enable = lib.mkEnableOption (lib.mdDoc "Apache Guacamole");
+      package = lib.mkPackageOptionMD pkgs "guacamole-server" { };
+
+      extraEnvironment = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [ ];
+        example = [ "ENVIRONMENT=production" ];
+        description = lib.mdDoc "Environment Variables to pass to guacd";
+      };
+
+      baseDir = lib.mkOption {
+        type = lib.types.path;
+        default = "/etc/guacamole";
+        description = lib.mdDoc ''
+          Location of $GUACAMOLE_HOME
+        '';
+      };
+
+      host = lib.mkOption {
+        default = "127.0.0.1";
+        description = lib.mdDoc ''
+          The host name or IP address the server should listen to.
+        '';
+        type = lib.types.str;
+      };
+
+      port = lib.mkOption {
+        default = 4822;
+        description = lib.mdDoc ''
+          The port the server should listen to.
+        '';
+        type = lib.types.port;
+      };
+
+      purifyOnStart = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = lib.mdDoc ''
+          On startup, the `baseDir` directory is populated with various files,
+          subdirectories and symlinks. If this option is enabled, these items
+          are first removed. This prevents interference from remainders of an
+          old configuration, so it's recommended to enable this option.
+        '';
+      };
+
+      guacamoleProperties = lib.mkOption {
+        type = lib.types.lines;
+        default = "";
+        description = lib.mdDoc ''
+          Configuration written to $GUACAMOLE_HOME/guacamole.properties
+        '';
+      };
+
+      logbackXml = lib.mkOption {
+        type = lib.types.lines;
+        default = "";
+        description = lib.mdDoc ''
+          Configuration written to $GUACAMOLE_HOME/logback.xml
+        '';
+      };
+
+      userMapping = lib.mkOption {
+        type = lib.types.lines;
+        default = "";
+        description = lib.mdDoc ''
+          Configuration written to $GUACAMOLE_HOME/user-mapping.xml
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.guacd = {
+      description = "Apache Guacamole server";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+
+      serviceConfig = {
+        Environment = [
+          "GUACAMOLE_HOME=${cfg.baseDir}"
+        ] ++ cfg.extraEnvironment;
+        ExecStart = "${lib.getExe cfg.package} -f -b ${cfg.host} -l ${toString cfg.port}";
+      };
+
+      preStart = ''
+        # Create and clean the base directory
+        ${lib.optionalString cfg.purifyOnStart ''
+        rm -rf ${cfg.baseDir}/{guacamole.properties,logback.xml,extensions,lib,user-mapping.xml}
+        ''}
+        mkdir -p ${cfg.baseDir}
+
+        # Setup guacamole.properties
+        ${lib.optionalString (cfg.guacamoleProperties != "") ''
+          cat << EOF > ${cfg.baseDir}/guacamole.properties
+          ${cfg.guacamoleProperties}
+          EOF
+        ''}
+
+        # Setup logback.xml
+        ${lib.optionalString (cfg.logbackXml != "") ''
+          cat << EOF > ${cfg.baseDir}/logback.xml
+          ${cfg.logbackXml}
+          EOF
+        ''}
+
+        # Setup user-mapping.xml
+        ${lib.optionalString (cfg.userMapping != "") ''
+          cat << EOF > ${cfg.baseDir}/user-mapping.xml
+          ${cfg.userMapping}
+          EOF
+        ''}
+      '';
+    };
+
+    services.tomcat = {
+      enable = true;
+      purifyOnStart = true;
+      webapps = [
+        pkgs.guacamole-client
+      ];
+      extraEnvironment = [ "GUACAMOLE_HOME=${cfg.baseDir}" ];
+    };
+  };
+}

--- a/overlay.nix
+++ b/overlay.nix
@@ -1,0 +1,93 @@
+{ self, lib, ... }: {
+  flake = {
+    overlays.default = final: prev: {
+      guacamole-server = prev.stdenv.mkDerivation (finalAttrs: {
+        pname = "guacamole";
+        version = "1.5.2";
+
+        src = prev.fetchFromGitHub {
+          owner = "apache";
+          repo = "guacamole-server";
+          rev = finalAttrs.version;
+          hash = "sha256-L1hFZ24kwTSHwqCUslnt5cBKkNh1cpVxu1ntTN1gFr0=";
+        };
+
+        NIX_CFLAGS_COMPILE = [
+          "-Wno-error=format-truncation"
+          "-Wno-error=format-overflow"
+        ];
+
+        nativeBuildInputs = with prev.pkgs; [
+          autoPatchelfHook
+          autoreconfHook
+          cairo
+          ffmpeg_4-headless
+          freerdp
+          libjpeg_turbo
+          libpng
+          libossp_uuid
+          libpulseaudio
+          libssh2
+          libtelnet
+          libvncserver
+          libvorbis
+          libwebp
+          libwebsockets
+          makeBinaryWrapper
+          openssl
+          pango
+          perl
+          pkg-config
+        ];
+
+        configureFlags = [
+          ''--with-freerdp-plugin-dir=${placeholder "out"}/lib''
+        ];
+
+        patchPhase = ''
+          patchShebangs ./src/protocols/rdp/**/*.pl
+        '';
+
+        postInstall = ''
+          ln -s ${prev.pkgs.freerdp}/lib/* $out/lib/
+          wrapProgram $out/sbin/guacd --prefix LD_LIBRARY_PATH ":" $out/lib
+        '';
+
+        meta = {
+          description = "Clientless remote desktop gateway";
+          homepage = "https://guacamole.incubator.apache.org/";
+          license = lib.licenses.asl20;
+          maintainers = [ ];
+          platforms = [ "x86_64-linux" "i686-linux" ];
+          mainProgram = "guacd";
+        };
+      });
+
+      guacamole-client = prev.stdenv.mkDerivation (finalAttrs: {
+        pname = "guacamole-client";
+        version = "1.5.2";
+
+        src = prev.fetchurl {
+          url = "https://archive.apache.org/dist/guacamole/1.5.2/binary/guacamole-1.5.2.war";
+          hash = "sha256-hu/DABbkA4lI2MGlw3oLBeONrdMQTbbsA3VbxuMRHEA=";
+        };
+
+        dontUnpack = true;
+        dontBuild = true;
+
+        installPhase = ''
+          mkdir -p $out/webapps
+          cp $src $out/webapps/guacamole.war
+        '';
+
+        meta = {
+          description = "Clientless remote desktop gateway";
+          homepage = "https://guacamole.incubator.apache.org/";
+          license = lib.licenses.asl20;
+          maintainers = [ ];
+          platforms = [ "x86_64-linux" "i686-linux" ];
+        };
+      });
+    };
+  };
+}


### PR DESCRIPTION
This PR:

- [x] Switch from `flake-utils` to `flake-parts` 
- [x] Upgrade to Guacamole 1.5.2
- [x] Refactor just a little bit the NixOS module

To test this PR:

1. You need to import this flake in your inputs: 
   `guacamole-nixos.url = "github:drupol/guacamole-nixos/switch-to-flake-parts";`
2. Import the overlay: `inputs.guacamole-nixos.overlays.default`
3. Import the Nixos module: `inputs.guacamole-nixos.nixosModules.guacamole`
4. Enable the module in your configuration: `services.guacamole.enable = true;`

